### PR TITLE
Add toy CNN example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This repository contains a collection of machine learning and deep learning mode
 - **Pointer Network** ([lstm/pointer-network.ipynb](lstm/pointer-network.ipynb))
   - Demonstrates how to use a Pointer Network to solve a toy sorting task.
   - Inspired by the paper: [Pointer Networks (Vinyals et al., 2015) - arXiv:1506.03134](https://arxiv.org/abs/1506.03134)
-
+- **Toy CNN** ([cnn/toy_cnn.py](cnn/toy_cnn.py))
+  - Demonstrates a small convolutional network inspired by AlexNet.
+ 
 More model examples will be added to this repository over time.
 
 ### Installation

--- a/cnn/toy_cnn.py
+++ b/cnn/toy_cnn.py
@@ -1,0 +1,50 @@
+"""Toy CNN example similar to AlexNet."""
+
+import torch
+from torch import nn
+
+class ToyAlexNet(nn.Module):
+    def __init__(self, num_classes: int = 10):
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(3, 64, kernel_size=11, stride=4, padding=2),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=3, stride=2),
+            nn.Conv2d(64, 192, kernel_size=5, padding=2),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=3, stride=2),
+            nn.Conv2d(192, 384, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(384, 256, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(256, 256, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.MaxPool2d(kernel_size=3, stride=2),
+        )
+        self.classifier = nn.Sequential(
+            nn.Dropout(),
+            nn.Linear(256 * 6 * 6, 4096),
+            nn.ReLU(inplace=True),
+            nn.Dropout(),
+            nn.Linear(4096, 4096),
+            nn.ReLU(inplace=True),
+            nn.Linear(4096, num_classes),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.features(x)
+        x = torch.flatten(x, 1)
+        x = self.classifier(x)
+        return x
+
+
+def demo():
+    # Create a ToyAlexNet and run a forward pass with random data.
+    net = ToyAlexNet(num_classes=10)
+    dummy = torch.randn(4, 3, 224, 224)  # batch of 4 images
+    out = net(dummy)
+    print("Output shape:", out.shape)
+
+
+if __name__ == "__main__":
+    demo()


### PR DESCRIPTION
## Summary
- add toy CNN implementation using PyTorch
- mention new example in README

## Testing
- `python3 -m py_compile cnn/toy_cnn.py`
- `python3 cnn/toy_cnn.py` *(fails: ModuleNotFoundError: No module named 'torch')*