### PR TITLE
Fix slow retrieval of pixel values

### DIFF
--- a/shared_utils/dataset_processor.py
+++ b/shared_utils/dataset_processor.py
@@ -617,7 +617,27 @@ class DatasetProcessor:
         if chunks:
             self.logger.info(f"Concatenating {len(chunks)} chunks for {split_name}...")
             final_dataset = concatenate_datasets(chunks)
-            self.logger.info(f"Successfully concatenated {split_name}: {len(final_dataset):,} total samples")
+
+            # Ensure the resulting dataset keeps the desired feature types.  In
+            # some cases `concatenate_datasets` drops the `Array3D` specification
+            # and the loaded dataset ends up storing lists of Python floats.  To
+            # avoid very slow retrieval of `pixel_values`, explicitly cast the
+            # features after concatenation.
+            if self.features is not None:
+                try:
+                    final_dataset = final_dataset.cast(self.features)
+                except Exception as e:
+                    self.logger.warning(f"Could not cast dataset features: {e}")
+
+            # Ensure fast retrieval by setting the format to return numpy arrays
+            try:
+                final_dataset.set_format(type="numpy")
+            except Exception as e:
+                self.logger.warning(f"Could not set dataset format: {e}")
+
+            self.logger.info(
+                f"Successfully concatenated {split_name}: {len(final_dataset):,} total samples"
+            )
             return final_dataset
         else:
             self.logger.warning(f"No valid chunks loaded for {split_name}")


### PR DESCRIPTION
## Summary
- keep Array3D features when recombining chunks to avoid list outputs for `pixel_values`
- set format to numpy after concatenation for faster access

## Testing
- `python -m py_compile shared_utils/dataset_processor.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68707be7e134833285de941dc30f475b